### PR TITLE
Update WailaCommonRegistrationEventJS.java

### DIFF
--- a/common/src/main/java/pie/ilikepiefoo/compat/jade/WailaCommonRegistrationEventJS.java
+++ b/common/src/main/java/pie/ilikepiefoo/compat/jade/WailaCommonRegistrationEventJS.java
@@ -40,7 +40,7 @@ public class WailaCommonRegistrationEventJS extends EventJS {
      * @param block    The highest level class to apply to
      * @return A builder for the data provider
      */
-    public ServerDataProviderBuilder<BlockAccessor> blockDataProvider(ResourceLocation location, Class<? extends BlockEntity> block) {
+    public ServerDataProviderBuilder<BlockAccessor> blockDataProvider(ResourceLocation location, Class<?> block) {
         ServerDataProviderBuilder<BlockAccessor> builder = new ServerDataProviderBuilder<>(location);
         registrationCallbacks.add(() -> registration.registerBlockDataProvider(new CustomServerDataProvider<>(builder), block));
         return builder;


### PR DESCRIPTION
Allow registering BlockDataProviders from classes that don't extend BlockEntity, as is the case within Jade itself (thus allowing data providers for blocks that don't have blockentities).